### PR TITLE
Add main key on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
     "jshint-stylish": "^1.0.0",
     "load-grunt-tasks": "^3.1.0",
     "time-grunt": "^1.0.0"
-  }
+  },
+  "main": "src/jquery.mask.js"
 }


### PR DESCRIPTION
main key on package.json allows to safely use browserify
